### PR TITLE
Remove broken statistic box (DE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ![Header](assets/Header.jpg "CovPass, Corona-Warn-App & CovPassCheck")
 
-<div align="center"> <img src="https://github-readme-stats.vercel.app/api?username=Ein-Tim&show_icons=true&theme=white&include_all_commits=true"></div align="center"><br>
-
 <div align="center"> <img src="https://komarev.com/ghpvc/?username=Ein-Tim"></div align="center"><br>
 
 ## Willkommen auf meinem GitHub Profil! 👋


### PR DESCRIPTION
The stats seem to be unavailable at this time. Thus removing them. Checking back in ca. 7 days. 

Add back with: 
```
<div align="center"> <img src="https://github-readme-stats.vercel.app/api?username=Ein-Tim&show_icons=true&theme=white&include_all_commits=true"></div align="center"><br>
```